### PR TITLE
chore: Bundle flowbite javascript instead using of CDN

### DIFF
--- a/src/components/Carousel.astro
+++ b/src/components/Carousel.astro
@@ -94,3 +94,7 @@ import Kkf_logo from "../assets/Kkf_logo.svg";
     </span>
   </button>
 </div>
+
+<script>
+  import { Carousel } from "flowbite";
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -33,11 +33,6 @@ const { title } = Astro.props;
 
     <link rel="canonical" href="https://galusek.de/" />
     <link rel="icon" type="image/svg+xml" href={favicon.src} />
-    <script
-      type="module"
-      is:inline
-      src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"
-    ></script>
   </head>
   <body>
     <div>


### PR DESCRIPTION
# chore: Bundle flowbite javascript instead using of CDN